### PR TITLE
📚 Add CI disable instructions

### DIFF
--- a/CI_DISABLE_INSTRUCTIONS.md
+++ b/CI_DISABLE_INSTRUCTIONS.md
@@ -1,0 +1,61 @@
+# CI Workflow Disable Instructions
+
+This repository currently runs CI tests for multiple operating systems, but you only need Arch Linux + Hyprland tests.
+
+## To Disable Non-Essential CI Tests
+
+Add `if: false` condition to these workflow files:
+
+### 1. Disable Linux Multi-Distro Tests
+File: `.github/workflows/linux.yml`
+```yaml
+name: linux
+
+on: [push, pull_request]
+
+# DISABLED: Only Arch Linux + Hyprland tests are required
+# To re-enable: remove the condition below
+if: false
+```
+
+### 2. Disable FreeBSD Tests
+File: `.github/workflows/freebsd.yml`
+```yaml
+name: freebsd
+
+on: [push, pull_request]
+
+# DISABLED: Only Arch Linux + Hyprland tests are required
+# To re-enable: remove the condition below
+if: false
+```
+
+### 3. Disable Nix Tests
+File: `.github/workflows/nix-tests.yml`
+```yaml
+name: "Nix-Tests"
+on:
+  pull_request:
+  push:
+
+# DISABLED: Only Arch Linux + Hyprland tests are required
+# To re-enable: remove the condition below
+if: false
+```
+
+## Workflows to Keep Active
+
+- ✅ `.github/workflows/ci-arch.yml` - Arch Linux + Hyprland tests
+- ✅ `.github/workflows/clang-format.yml` - Code formatting checks
+- ✅ `.github/workflows/labeler.yml` - Issue labeling
+
+## Benefits
+
+- Reduces CI noise and build failures
+- Focuses on your primary use case (Arch + Hyprland)
+- Faster PR processing
+- Easily re-enableable by removing the `if: false` conditions
+
+## Note
+
+The OAuth token used by this AI assistant doesn't have the `workflow` scope required to modify GitHub workflow files. You'll need to make these changes manually or with a token that has the appropriate permissions.


### PR DESCRIPTION
This PR adds documentation for disabling non-essential CI tests.

## Problem
The repository runs CI tests for multiple operating systems (Alpine, Debian, Fedora, OpenSUSE, Gentoo, FreeBSD, Nix), but you only need Arch Linux + Hyprland tests.

## Solution
Added `CI_DISABLE_INSTRUCTIONS.md` with step-by-step instructions to disable the non-essential tests while keeping:
- ✅ Arch Linux + Hyprland tests (`ci-arch.yml`)
- ✅ Code formatting checks (`clang-format.yml`)
- ✅ Issue labeling (`labeler.yml`)

## Benefits
- Reduces CI noise and build failures
- Focuses on your primary use case
- Faster PR processing
- Easily re-enableable

## Note
Due to OAuth scope limitations, the AI assistant cannot directly modify workflow files. You'll need to apply these changes manually using the provided instructions.